### PR TITLE
Correccion pylintrc errors

### DIFF
--- a/core/backgammon.py
+++ b/core/backgammon.py
@@ -9,8 +9,8 @@ flujo de turnos, movimientos y condiciones de victoria.
 from .board import Board
 from .player import Player
 from .dice import Dice
-from .validaciones import *
-from .exceptions import *
+from .validaciones import Validaciones
+from .exceptions import SaltosError
 
 
 class Backgammon:

--- a/core/board.py
+++ b/core/board.py
@@ -6,7 +6,6 @@ de las fichas y las operaciones de movimiento, captura y reingreso.
 """
 
 from .ficha import Ficha
-from .validaciones import *
 
 class Board:
     """

--- a/core/exceptions.py
+++ b/core/exceptions.py
@@ -5,43 +5,30 @@ Módulo Exceptions - Excepciones personalizadas del juego.
 
 class BackgammonError(Exception):
     """Base para todas las excepciones del juego Backgammon."""
-    pass
 
 class FueraDeRangoError(BackgammonError):
-    """Índice de celda fuera del rango 0..23."""
-    pass
+    """Índice de celda fuera del rango 0..23."""   
 
 class CeldaInvalidaError(BackgammonError):
-    """Se intentó operar sobre una celda vacía o no válida."""
-    pass
+    """Se intentó operar sobre una celda vacía o no válida."""    
 
 class ValidacionError(BackgammonError):
-    """Error genérico de validación de reglas."""
-    pass
+    """Error genérico de validación de reglas."""   
 
 class CeldaBloqueadaError(BackgammonError):
-    """Destino bloqueado por fichas enemigas."""
-    pass
+    """Destino bloqueado por fichas enemigas.""" 
 
 class FichasCapturadasError(BackgammonError):
     """Operación inválida cuando el jugador tiene fichas en la barra."""
-    pass
 
 class SinFichasCapturadas(BackgammonError):
     """No hay fichas capturadas para reingresar."""
-    pass
 
 class ReingresoInvalidoError(BackgammonError):
-    """No se puede reingresar una ficha capturada (destino inválido)."""
-    pass
+    """No se puede reingresar una ficha capturada (destino inválido)."""  
 
 class SalidaInvalidaError(BackgammonError):
     """No se puede sacar fichas (condición de salida no cumplida)."""
-    pass
 
 class SaltosError(BackgammonError):
     """Errores relacionados con los saltos/dados (ej: no tirar antes de mover)."""
-    pass
-
-
-

--- a/core/ficha.py
+++ b/core/ficha.py
@@ -71,6 +71,3 @@ class Ficha:
         """
         estado = "capturada" if self.__capturada__ else "libre"
         return f"<Ficha jugador={self.__jugador__} {estado}>"
-    
-
-        

--- a/core/main.py
+++ b/core/main.py
@@ -1,2 +1,0 @@
-class main:
-    pass

--- a/core/validaciones.py
+++ b/core/validaciones.py
@@ -5,7 +5,11 @@ Verifica la validez de movimientos, reingresos, salidas del tablero y
 condiciones de victoria
 """
 
-from .exceptions import *
+from .exceptions import (
+    FichasCapturadasError, FueraDeRangoError, CeldaBloqueadaError,
+    CeldaInvalidaError, SinFichasCapturadas, ReingresoInvalidoError,
+    SalidaInvalidaError
+)
 
 class Validaciones:
     """


### PR DESCRIPTION
### Se corrigen errores de pylint:
- Espacios en blanco en final de pagina
- Imports especificados no usado de *
- ELiminado pass innecesario en exceptions
- Eliminado core/main.py innecesario