### PR TITLE
Eliminado test de player para funcion __repr__

### DIFF
--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -11,10 +11,3 @@ class TestPlayer(unittest.TestCase):
         p = Player("Luchito")
         p.set_name("Lucas")
         self.assertEqual(p.get_name(), "Lucas")
-
-    def test_player_repr(self):
-        p = Player("Luchito")
-        self.assertEqual(repr(p), "Player: Luchito")
-        p.set_name("Lucas")
-        self.assertEqual(repr(p), "Player: Lucas")  
-    


### PR DESCRIPTION
### Cambio:
- Se elimina test_player_repr al eliminar metodo __repr__ desde modulo player